### PR TITLE
chore: add .gitattributes for line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,8 +19,6 @@
 *.svg text
 *.csv text
 *.sh text
-*.env text
-
 # Shell scripts should use LF only
 *.sh text eol=lf
 


### PR DESCRIPTION
Closes #104 

Windows and unix systems use different line endings, the .gitattributes files allows us to set how git treats line endings so we don't have to worry about linting failing because files have inconsistent line endings. 