### PR TITLE
took out useless (?) z index

### DIFF
--- a/src/components/coding-session/editor/cursor-overlay.tsx
+++ b/src/components/coding-session/editor/cursor-overlay.tsx
@@ -12,7 +12,7 @@ export function CursorOverlay({ cursorRef }: CursorOverlayProps) {
     <div
       ref={cursorRef}
       className={`
-        pointer-events-none absolute top-0 left-0 z-[2000] hidden size-2.5
+        pointer-events-none absolute top-0 left-0 hidden size-2.5
         -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-600/90
       `}
     />


### PR DESCRIPTION
Closes #164 

Was this z index there for a reason? Wasnt showing up beforehand cuz of a default? if not this is safe to merge but if that was the case we should prob set a z index so it doesnt default and get hidden behind anything 